### PR TITLE
feat: migrate to github packages and improve dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ To test local Paplin changes without publishing:
   Run `./gradlew -Ppaplin.local.path=../paplin runServer` (adjust the path to your local Paplin clone).
 
 - **Maven local**:  
-  Publish Paplin locally with `./gradlew publishToMavenLocal`, then run `./gradlew -PuseMavenLocal runServer`.
-
+  In your local Paplin repository, run `./gradlew publishToMavenLocal`, then in this project run `./gradlew -PuseMavenLocal runServer`.
 ## Dependencies
 
 Paplin is fetched from GitHub Packages. Versions are managed in `gradle/libs.versions.toml`:

--- a/README.md
+++ b/README.md
@@ -34,9 +34,19 @@ Then test the example command:
 /mycommand Hello from Paplin!
 ```
 
+## Local Development
+
+To test local Paplin changes without publishing:
+
+- **Composite build** (no publish step):  
+  Run `./gradlew -Ppaplin.local.path=../paplin runServer` (adjust the path to your local Paplin clone).
+
+- **Maven local**:  
+  Publish Paplin locally with `./gradlew publishToMavenLocal`, then run `./gradlew -PuseMavenLocal runServer`.
+
 ## Dependencies
 
-Paplin is fetched from Repsy Maven. Versions are managed in `gradle/libs.versions.toml`:
+Paplin is fetched from GitHub Packages. Versions are managed in `gradle/libs.versions.toml`:
 
 ```toml
 [versions]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,9 +13,16 @@ version = "1.0.0"
 
 repositories {
     mavenCentral()
+    if (providers.gradleProperty("useMavenLocal").isPresent) {
+        mavenLocal()
+    }
     maven {
         name = "Paplin"
-        url = uri("https://repo.repsy.io/mvn/jaroxcraft/paplin")
+        url = uri("https://maven.pkg.github.com/JaroxCraft/paplin")
+        credentials {
+            username = providers.environmentVariable("GITHUB_ACTOR").orNull
+            password = providers.environmentVariable("GITHUB_TOKEN").orNull
+        }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,4 +5,9 @@ pluginManagement {
     }
 }
 
+val paplinLocalPath = providers.gradleProperty("paplin.local.path").orNull
+if (paplinLocalPath != null) {
+    includeBuild(paplinLocalPath)
+}
+
 rootProject.name = "paplin-example-project"


### PR DESCRIPTION
Migrates Paplin repository from Repsy to GitHub Packages. Adds conditional mavenLocal() and includeBuild support for easier local Paplin development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Local Development section with steps for testing changes locally without publishing.
  * Updated dependency notes to indicate the project is now fetched from GitHub Packages and retained version-management guidance.

* **Chores**
  * Switched primary dependency registry to GitHub Packages in the build config.
  * Added support for optional local composite builds to facilitate local testing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/paplin-example-project/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->