### PR TITLE
feat: replace Paplin command DSL with CommandAPI Kotlin DSL in example

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,9 @@ group = "de.jarox"
 version = "1.0.0"
 
 repositories {
+    if (providers.gradleProperty("useMavenLocal").orNull == "true") {
+        mavenLocal()
+    }
     mavenCentral()
     maven {
         name = "Paplin"
@@ -24,6 +27,7 @@ dependencies {
 
     shadow(kotlin("stdlib"))
 
+    implementation(libs.commandapi.paper.shade)
     implementation("de.jarox:paplin:${libs.versions.paplin.get()}+${libs.versions.minecraft.get()}")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
+useMavenLocal=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
-useMavenLocal=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,11 @@
 [versions]
 kotlin = "2.3.21"
 minecraft = "26.1.2"
-paplin = "1.0.0"
+paplin = "1.1.0"
+commandapi = "11.2.0"
+
+[libraries]
+commandapi-paper-shade = { module = "dev.jorel:commandapi-paper-shade", version.ref = "commandapi" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/main/kotlin/de/jarox/paplin/example/ExamplePlugin.kt
+++ b/src/main/kotlin/de/jarox/paplin/example/ExamplePlugin.kt
@@ -1,37 +1,34 @@
 package de.jarox.paplin.example
 
-import com.mojang.brigadier.arguments.StringArgumentType
 import de.jarox.paplin.PaplinPlugin
 import de.jarox.paplin.chat.component
-import de.jarox.paplin.command.argument
-import de.jarox.paplin.command.command
-import de.jarox.paplin.command.runs
 import de.jarox.paplin.event.listen
 import de.jarox.paplin.extension.broadcast
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.commandTree
+import dev.jorel.commandapi.kotlindsl.greedyStringArgument
 import net.kyori.adventure.text.Component
 import org.bukkit.event.block.BlockBreakEvent
 
 class ExamplePlugin : PaplinPlugin() {
-
     override fun enable() {
         // register a simple command
-        command("mycommand") {
-            runs {
-                // automatically only allow players to execute this command
-                player.sendMessage(Component.text("Hello, world!"))
+        commandTree("mycommand") {
+            anyExecutor { sender, _ ->
+                sender.sendMessage(Component.text("Hello, world!"))
             }
 
-            // simple argument
-            argument("message", StringArgumentType.greedyString()) {
-                runs {
-                    this.source.sender.sendMessage(component(getArgument("message")))
+            greedyStringArgument("message") {
+                anyExecutor { sender, args ->
+                    val message = args["message"] as String
+                    sender.sendMessage(component(message))
                 }
             }
         }
 
         // register a simple listener
-        listen<BlockBreakEvent> { event ->
-            broadcast(event.player.name().append(component(" broke ")).append(component(event.block.type.blockTranslationKey!!)))
+        listen<BlockBreakEvent> {
+            broadcast(component("${it.player.name} broke a block!"))
         }
     }
 }


### PR DESCRIPTION
Migrate from Paplin's removed `command {}` / `runs {}` / `argument {}` DSL to CommandAPI's Kotlin DSL (`commandTree {}` / `anyExecutor {}` / `greedyStringArgument {}`).

### Changes
- Add CommandAPI (`dev.jorel:commandapi-paper-shade`) as a dependency
- Add conditional `mavenLocal()` for local Paplin development (`useMavenLocal=true`)
- Rewrite `ExamplePlugin` command registration using CommandAPI's Kotlin DSL
- Simplify `BlockBreakEvent` listener body
- Bump Paplin dependency to `1.1.0` (matching the newly released version)

### Background
Paplin 1.0.0 had its own Brigadier-based command DSL which was removed (replaced by CommandAPI internally). The example should use the same command API that Paplin itself now depends on, rather than an API that no longer exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped library versions and added a packaged command API dependency.
  * Build now supports conditional use of a local Maven repository.

* **Refactor**
  * Example plugin rewritten to use a newer command DSL and broader executor handling.
  * Listener registration simplified and broadcast message formatting streamlined.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaroxCraft/paplin-example-project/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->